### PR TITLE
reference webpage on 3D_Analysis.py

### DIFF
--- a/XH_Texture_Analysis/3D_Analysis.py
+++ b/XH_Texture_Analysis/3D_Analysis.py
@@ -242,6 +242,8 @@ featureClasses = getFeatureClasses()
 
 # Origin and Spacing are not the same between the image and the defect mask. 
 # This sets the parameters to be the same between the image and defect
+# Webpage for reference: https://github.com/SimpleITK/SimpleITK/issues/561
+
 imageName_Lam_patchy.SetOrigin(mask_defect_sitk_Lam_patchy.GetOrigin())
 imageName_Lam_patchy.SetSpacing(mask_defect_sitk_Lam_patchy.GetSpacing())
 


### PR DESCRIPTION
Added reference webpage for 3D_Analysis.py file to set the parameters in case the mask and the image have different origins, orientations, spacing, etc. 
https://github.com/SimpleITK/SimpleITK/issues/561